### PR TITLE
Add Twig convenience function for inline table JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datatables Plugin
 
-The **Datatables** Plugin is for [Grav CMS](http://github.com/getgrav/grav). It provides two shortcodes to embed the awesome [DataTables](https://datatables.net) jQuery plugin (v1.10.16).
+The **Datatables** Plugin is for [Grav CMS](http://github.com/getgrav/grav). It provides two shortcodes and a Twig utility function to embed the awesome [DataTables](https://datatables.net) jQuery plugin (v1.10.16).
 
 ## Installation
 
@@ -153,8 +153,62 @@ $(document).ready( function () {
   });
 </script>
 ```
+
+### grav.datatables.utils.format Twig function
+
+This function allows developers to easily add the required Javascript to format an HTML table that is already being rendered, using DataTables _from within a Twig template_.
+
+**Syntax:** _void_ format(_string_ id, _array_ table\_options(={}), _array_ asset\_options(={'group': 'bottom'}))
+
+_"Format the table with id `id` using [DataTables options](https://datatables.net/reference/option/) `table_options` and [Grav asset manager options](https://learn.getgrav.org/15/themes/asset-manager#for-js) `asset_options`."_
+
+**Example:**
+
+```twig
+<table id="qwerty">
+  <thead><tr><th>Field 1</th><th>Field2</th></tr></thead>
+  <tbody><tr><td>Data</td><td>1234</td></tr></tbody>
+</table>
+…
+{% do grav.datatables.utils.format('qwerty', {'pageLength': 25}) %}
+```
+
+which is the Twig equivalent of:
+
+```twig
+<table id="qwerty">…
+…
+{% set datatables_inline_js %}
+$(document).ready( function () {
+    $('#qwerty').DataTable({
+      'pageLength': 25
+      });
+} );
+{% endset %}
+{% do assets.addInlineJS(datatables_inline_js, {'group': 'bottom'} )  %}
+```
+
+and would be served to the browser as:
+
+```HTML
+<table id="qwerty">…
+…
+<!-- somewhere near the bottom of <body> … -->
+<script>
+$(document).ready( function () {
+    $('#qwerty').DataTable({
+      'pageLength': 25
+      });
+} );
+</script>
+```
+
+So essentially it's a very convenient Twig shorthand for the Javascript required to format a table.
+
+> `format` could also be invoked using Twig print expression delimiters (eg. `{{ grav.datatables.utils.format('mytable') }}`), but since this function returns no value it is more idiomatic to use a [`do` tag](https://twig.symfony.com/doc/2.x/tags/do.html).
+
 ## Limitations
-This version of the shortcode does not allow for DataTable plugins. This should be fairly easy to add, perhaps by including plugin configuration codes for each plugin required.  
+This version of the plugin does not allow for DataTable plugins. This should be fairly easy to add, perhaps by including plugin configuration codes for each plugin required.  
 
 However, it would be interesting to see whether there is any need to add plugins.
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,6 +1,6 @@
 name: Datatables
-version: 1.0.4
-description: shortcode to embed DataTables jquery plugin
+version: 1.0.3
+description: Shortcodes and Twig utility function to embed DataTables jquery plugin
 icon: plug
 author:
   name: Richard Hainsworth
@@ -10,9 +10,6 @@ keywords: grav, plugin, datatables
 bugs: https://github.com/finanalyst/grav-plugin-datatables/issues
 docs: https://github.com/finanalyst/grav-plugin-datatables/blob/master/README.md
 license: MIT
-
-dependencies:
-  - shortcode-core
 
 form:
   validation: strict

--- a/datatables.php
+++ b/datatables.php
@@ -10,7 +10,7 @@ use RocketTheme\Toolbox\Event\Event;
  */
 class DatatablesPlugin extends Plugin
 {
-    protected $script;
+    protected $datatables;
 
     public static function getSubscribedEvents()
     {
@@ -31,7 +31,9 @@ class DatatablesPlugin extends Plugin
         if ($this->isAdmin()) {
             return;
         }
-        $this->grav['datatables'] = $this->script = '';
+        $this->datatables['script'] = '';
+        $this->datatables['utils'] = new Datatables_utilities();
+        $this->grav['datatables'] = $this->datatables;
     }
 
     public function onAssetsInitialized() {
@@ -50,4 +52,22 @@ class DatatablesPlugin extends Plugin
         $this->grav['shortcode']->registerAllShortcodes(__DIR__.'/shortcodes');
     }
 
+}
+
+class Datatables_utilities {
+
+    public function format($id, $table_options=[], $asset_options = ['group' => 'bottom']) {
+        // suggested/example invocation: {% do grav.datatables.utils.format('mytable', {'pageLength': 25}) %}
+        global $grav;
+
+        $options = ( empty($table_options) ? '' : json_encode($table_options) );
+
+        $js = <<<EOJ
+        \$(document).ready( function () {
+            \$('#{$id}').DataTable({$options});
+        } );
+EOJ;
+        $grav['assets']->addInlineJs($js, $asset_options);
+        
+    }
 }


### PR DESCRIPTION
This is documented in changes to `README.md`. It adds the required inline JS asset that will render an existing table as a DataTable.