### PR TITLE
I fixed the plugin :D

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Datatables
-version: 1.0.3
+version: 1.0.5
 description: shortcode to embed DataTables jquery plugin
 icon: plug
 author:
@@ -12,8 +12,8 @@ docs: https://github.com/finanalyst/grav-plugin-datatables/blob/master/README.md
 license: MIT
 
 dependencies:
-  - { name: shortcode-core }
-  - { name: error }
+  - { name: shortcode-core, tested: "5.1.3" }
+  - { name: error, tested: "1.8.0" }
 
 form:
   validation: strict

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Datatables
-version: 1.0.4
+version: 1.0.3
 description: shortcode to embed DataTables jquery plugin
 icon: plug
 author:
@@ -12,7 +12,8 @@ docs: https://github.com/finanalyst/grav-plugin-datatables/blob/master/README.md
 license: MIT
 
 dependencies:
-  - shortcode-core
+  - { name: shortcode-core }
+  - { name: error }
 
 form:
   validation: strict

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -14,6 +14,7 @@ license: MIT
 dependencies:
   - { name: shortcode-core, tested: "5.1.3" }
   - { name: error, tested: "1.8.0" }
+  - { name: problems, tested: "2.1.1" }
 
 form:
   validation: strict

--- a/shortcodes/DataTablesScript.php
+++ b/shortcodes/DataTablesScript.php
@@ -6,14 +6,14 @@ class DataTablesScript extends Shortcode
 {
   public function init()
   {
-    $this->shortcode->getHandlers()->add('dt-script', function(ShortcodeInterface $sc) {
+    $this->shortcode->getHandlers()->add('dt-script', function (ShortcodeInterface $sc) {
       $content = trim($sc->getContent());
-      while ( preg_match('/\<[^>]*\>/', $content, $matches))  { // strip tags from both ends
+      while (preg_match('/\<[^>]*\>/', $content, $matches)) { // strip tags from both ends
         $tag = strlen($matches[0]);
         $len = strlen($content);
-        $content = substr($content,$tag,$len-$tag-$tag-1);
+        $content = substr($content, $tag, $len - $tag - $tag - 1);
       }
-      if ( isset($this->grav['datatables'] )) $this->grav['datatables'] .= $content;
+      if (isset($this->grav['datatables'])) $this->grav['datatables'] .= $content;
       return '';
     });
   }

--- a/shortcodes/DataTablesShortcode.php
+++ b/shortcodes/DataTablesShortcode.php
@@ -16,13 +16,13 @@ class DataTablesShortcode extends Shortcode
 
       $hasTable = preg_match('/\<table[^>]*?\>(.*)\<\/table[^>]*\>/ims', $content);
       if ($hasTable === FALSE or $hasTable == 0) {
-        return htmlspecialchars_decode($this->twig->processTemplate(
+        return $this->twig->processTemplate(
           'partials/datatables-error.html.twig',
           [
             'message' => 'Shortcode content does not appear to have a valid &lt;table&gt;...&lt;/table&gt; element. Got instead:',
             'content' => $content
           ]
-        ));
+        );
       }
 
       // Get id from html and remove the id attribute
@@ -60,7 +60,6 @@ class DataTablesShortcode extends Shortcode
           'snippet' => $this->grav['datatables']
         ]
       );
-      $output = htmlspecialchars_decode($output);
       $this->grav['datatables'] = '';
       return $output;
     });

--- a/shortcodes/DataTablesShortcode.php
+++ b/shortcodes/DataTablesShortcode.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace Grav\Plugin\Shortcodes;
+
 use Thunder\Shortcode\Shortcode\ShortcodeInterface;
 use Grav\Common\Utils;
 
@@ -7,57 +9,55 @@ class DataTablesShortcode extends Shortcode
 {
   public function init()
   {
-    $this->shortcode->getHandlers()->add('datatables', function(ShortcodeInterface $sc) {
+    $this->shortcode->getHandlers()->add('datatables', function (ShortcodeInterface $sc) {
       $content = $sc->getContent();
       $parameters = $sc->getParameters();
       $id = '';
-      $res = preg_match('/\<table[^>]*?\>(.*)\<\/table[^>]*\>/ims',$content);
-      // does table have a table attached?
-      if ( $res === FALSE or $res == 0) {
-        // error some where
-        return $this->twig->processTemplate('partials/datatables-error.html.twig',
-        [ 'message' => 'Shortcode content does not appear to have a valid &lt;table&gt;...&lt;/table&gt; element. Got instead:',
-          'content' => $content
-        ] );
-      } else {
-        $res = preg_match('/(\<table\s[^>]*)id="(.*?)"(.*\>)/ims',$content,$matches);
-        if ( $res == 1 ) {
-          $this->grav['debugger']->addMessage('found id');
-          if ( ! $matches[2] || preg_match( '/\s/',$matches[2]) == 1 ) {
-            // id either has spaces - illegal - or is null, so strip output
-            $content = $matches[1] . $matches[3];
-          } else {
-              $id = $matches[2];
-            }
-          }
-      }
-      if ( ! $id ) {
-        if ( isset( $params['grav-id'])) {
-            $id = trim($params['grav-id']);
-            unset($params['grav-id']);
-            if (preg_match('/\s/')) { $id = '';} // ignore an illegal id
-        }
-        // this occurs if content has <table without an id, or an illegal id has be stripped out
-        if (! $id ) $id = Utils::generateRandomString(10);
-        $pos = stripos('<table', $content);
-        $end = substr($content,7);
-        $content = substr_replace($content," id=\"$id\" ",7) . $end;
-      }
-      $options='';
-      if ( $parameters ) {
-        $got = array('"true"','"TRUE"','"True"','"false"','"FALSE"', '"False"' );
-        $want = array('true','true','true','false','false','false');
-        $options = str_replace($got,$want,json_encode($parameters));
-      }
-      $output = $this->twig->processTemplate('partials/datatables.html.twig',
+
+      $hasTable = preg_match('/\<table[^>]*?\>(.*)\<\/table[^>]*\>/ims', $content);
+      if ($hasTable === FALSE or $hasTable == 0) {
+        return htmlspecialchars_decode($this->twig->processTemplate(
+          'partials/datatables-error.html.twig',
           [
-            'id' => $id,
-            'content' => $content,
-            'options' => $options,
-            'snippet' => $this->grav['datatables']
-          ]);
-        $this->grav['datatables'] = ''; // clear snippet for next table invocation
-        return $output;
+            'message' => 'Shortcode content does not appear to have a valid &lt;table&gt;...&lt;/table&gt; element. Got instead:',
+            'content' => $content
+          ]
+        ));
+      }
+
+      $hasIdAttribute = preg_match('/(\<table\s[^>]*)id="(.*?)"(.*\>)/ims', $content, $matches);
+      if ($hasIdAttribute == 1) {
+        $invalidId = (!$matches[2] || preg_match('/\s/', $matches[2]) == 1);
+        if ($invalidId) {
+          $content = $matches[1] . $matches[3];
+        } else {
+          $id = $matches[2];
+        }
+      }
+
+      if (!$id) {
+        $id = trim($parameters['id'] ?? $parameters['grav-id'] ?? '');
+        unset($parameters['id']);
+        unset($parameters['grav-id']);
+        if (!$id) $id = Utils::generateRandomString(10);
+        $pos = stripos('<table', $content);
+        $end = substr($content, $pos);
+        $content = substr_replace($content, " id=\"$id\" ", 7) . $end;
+      }
+
+      $options = preg_replace(['/"true"/i', '/"false"/i'], ['true', 'false'], json_encode($parameters));
+      $output = $this->twig->processTemplate(
+        'partials/datatables.html.twig',
+        [
+          'id' => $id,
+          'content' => $content,
+          'options' => $options,
+          'snippet' => $this->grav['datatables']
+        ]
+      );
+      $output = htmlspecialchars_decode($output);
+      $this->grav['datatables'] = '';
+      return $output;
     });
   }
 }

--- a/shortcodes/DataTablesShortcode.php
+++ b/shortcodes/DataTablesShortcode.php
@@ -25,27 +25,32 @@ class DataTablesShortcode extends Shortcode
         ));
       }
 
+      // Get id from html and remove the id attribute
       $hasIdAttribute = preg_match('/(\<table\s[^>]*)id="(.*?)"(.*\>)/ims', $content, $matches);
       if ($hasIdAttribute == 1) {
-        $invalidId = (!$matches[2] || preg_match('/\s/', $matches[2]) == 1);
-        if ($invalidId) {
-          $content = $matches[1] . $matches[3];
-        } else {
-          $id = $matches[2];
-        }
+        $content = $matches[1] . $matches[3];
+        $id = $matches[2];
       }
 
-      if (!$id) {
-        $id = trim($parameters['id'] ?? $parameters['grav-id'] ?? '');
-        unset($parameters['id']);
-        unset($parameters['grav-id']);
-        if (!$id) $id = Utils::generateRandomString(10);
-        $pos = stripos('<table', $content);
-        $end = substr($content, $pos);
-        $content = substr_replace($content, " id=\"$id\" ", 7) . $end;
+      // Get id from parameters, overriding any existing id
+      $id = trim($parameters['id'] ?? $parameters['grav-id'] ?? '');
+      unset($parameters['id']);
+      unset($parameters['grav-id']);
+
+      // If there's no id or the id is invalid, generate a new id
+      $invalidId = (preg_match('/\s/', $id) == 1);
+      if ($invalidId || !$id) {
+        $id = Utils::generateRandomString(10);
       }
 
+      // Insert the id attribute
+      $content = preg_replace('/\<table/i', "\\0 id=\"$id\"", $content);
+
+      // JSON encode the shortcode parameters
+      // Stripping quotes from "true" and "false", effectively casting to boolean
       $options = preg_replace(['/"true"/i', '/"false"/i'], ['true', 'false'], json_encode($parameters));
+
+      // Process the template and decode the output
       $output = $this->twig->processTemplate(
         'partials/datatables.html.twig',
         [

--- a/templates/partials/datatables-error.html.twig
+++ b/templates/partials/datatables-error.html.twig
@@ -1,6 +1,2 @@
-<div style="background-color: #f3b624; color: red; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">
-{{message}}
-</div>
-<div style="background-color: #f3b624; color: blue; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">
-{{content}}
-</div>
+<div style="background-color: #f3b624; color: red; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">{{ message }}</div>
+<div style="background-color: #f3b624; color: blue; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">{{ content|raw }}</div>

--- a/templates/partials/datatables-error.html.twig
+++ b/templates/partials/datatables-error.html.twig
@@ -1,2 +1,2 @@
 <div style="background-color: #f3b624; color: red; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">{{ message }}</div>
-<div style="background-color: #f3b624; color: blue; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">{{ content|raw }}</div>
+<div style="background-color: #f3b624; color: blue; font-weight: bold; padding: 0 10px 0 10px; margin: auto; border-radius: 20px;">{{ content }}</div>

--- a/templates/partials/datatables.html.twig
+++ b/templates/partials/datatables.html.twig
@@ -1,4 +1,4 @@
-{{ content }}
+{{ content|raw }}
 
 <script>
   $(document).ready( function () {

--- a/templates/partials/datatables.html.twig
+++ b/templates/partials/datatables.html.twig
@@ -1,10 +1,11 @@
 {{ content }}
+
 <script>
-$(document).ready( function () {
-    $('#{{  id }}').DataTable({% if options %}{{ options }}{% endif %});
-    {% if snippet %}
-      var selector = '#{{ id }}';
-      {{ snippet }}
+  $(document).ready( function () {
+      $('#{{  id }}').DataTable({% if options %}JSON.parse("{{options|escape('js')}}"){% endif %});
+      {% if snippet %}
+        const selector = '#{{ id }}';
+        {{ snippet }}
       {% endif %}
-} );
+  } );
 </script>


### PR DESCRIPTION
Fixes #6 

The only thing required to fix #6 is adding `|raw` in the twig template. That's it. Four characters. I did a bunch of other stuff while figuring this out. If there's too much stuff and you don't feel like pulling this I can make a simpler PR with less changes.

## Changelog:

 - Ran a formatter on the changed files
 - Declared all dependencies (and added tested versions)
 - Refactored id extraction and insertion
 - Now handles invalid id from shortcode eg. `grav-id="id with spaces"`. It generates a new id if the one in parameters is invalid.
 - Add support for `id` shortcode parameter while keeping backwards compatibility with `grav-id`
 - Prioritize the id passed through parameters. If there's an id in the shortcode content AND in the parameters, the id is replaced with the one in the parameters.
 - Used twig `|escape('js')` to escape the options for DataTable. This in combination with JSON parsing the options allows passing more complicated options than just true / false
 - And of course used `|raw` in the template to output the table as HTML